### PR TITLE
Add `/kcpp-list` and `/kcpp-unload` for better QR menu creation.

### DIFF
--- a/index.js
+++ b/index.js
@@ -245,7 +245,7 @@ jQuery(async function() {
                 </div>
                 <div class="flex-container">
                     <input id="kobold_api_load_button" class="menu_button" type="submit" value="Reload KoboldCPP Config" />
-                    <input id="kobold_api_unload_button" class="menu_button" type="button" value="Unload" />
+                    <input id="kobold_api_unload_button" class="menu_button" type="button" value="Test/Save Unload Config" />
                 </div>
             </div>
         </div>

--- a/index.js
+++ b/index.js
@@ -147,6 +147,36 @@ async function onModelLoad(args, value){
     .catch(error => console.log("KoboldCCP Switch API Load Failed: " + error.message));
 }
 
+async function onModelUnload(){
+    extension_settings.koboldapi.unload = $('#kobold_api_unload_list').val();
+    saveSettingsDebounced();
+
+    const modelName = $('#kobold_api_unload_list').val();
+    
+    await fetch(`${extension_settings.koboldapi.url}/api/admin/reload_config`, {
+        method: "POST",
+        body: JSON.stringify({
+          filename: modelName,
+        }),
+        headers: {
+          "Content-type": "application/json; charset=UTF-8"
+        }
+    })
+    .then( async () => {
+        reconnect_attempts = max_reconnect_attempts;
+        while (reconnect_attempts > 0)
+        {
+            reconnect_attempts--;
+            console.log("Try to reconnect: " + reconnect_attempts);
+            $('#api_button_textgenerationwebui').click();
+            await sleep(1000);
+            if (reconnect_attempts > 0)
+                $('.api_loading').click();
+        }
+    })
+    .catch(error => console.log("KoboldCCP Switch API Load Failed: " + error.message));
+}
+
 function onStatusChange(e)
 {
     if ( e != "no_connection")

--- a/index.js
+++ b/index.js
@@ -56,8 +56,6 @@ async function loadSettings()
         extension_settings.koboldapi = { "url": "", "model": "", "unload": "" };
     if ( ! extension_settings.koboldapi.url )
         extension_settings.koboldapi.url = "";
-//    if ( ! extension_settings.koboldapi.context )
-//        extension_settings.koboldapi.context = 8;
     if ( ! extension_settings.koboldapi.model )
         extension_settings.koboldapi.model = "";
     if ( ! extension_settings.koboldapi.model )
@@ -122,38 +120,6 @@ async function onModelLoad(args, value){
     saveSettingsDebounced();
 
     const modelName = value    ?? $('#kobold_api_model_list').val();
-//    const ctxget   = args.ctx ?? $('#kobold_api_model_context').val();
-//    const cmdget   = args.cmd ?? $('#kobold_api_model_opt').val();
-    
-    await fetch(`${extension_settings.koboldapi.url}/api/admin/reload_config`, {
-        method: "POST",
-        body: JSON.stringify({
-          filename: modelName,
-        }),
-        headers: {
-          "Content-type": "application/json; charset=UTF-8"
-        }
-    })
-    .then( async () => {
-        reconnect_attempts = max_reconnect_attempts;
-        while (reconnect_attempts > 0)
-        {
-            reconnect_attempts--;
-            console.log("Try to reconnect: " + reconnect_attempts);
-            $('#api_button_textgenerationwebui').click();
-            await sleep(1000);
-            if (reconnect_attempts > 0)
-                $('.api_loading').click();
-        }
-    })
-    .catch(error => console.log("KoboldCCP Switch API Load Failed: " + error.message));
-}
-
-async function onModelUnload(){
-    extension_settings.koboldapi.unload = $('#kobold_api_unload_list').val();
-    saveSettingsDebounced();
-
-    const modelName = $('#kobold_api_unload_list').val();
     
     await fetch(`${extension_settings.koboldapi.url}/api/admin/reload_config`, {
         method: "POST",

--- a/index.js
+++ b/index.js
@@ -31,10 +31,12 @@ function onKoboldContextChanged() {
 }
 */
 
+/*
 function onKoboldCModelChanged() {
     extension_settings.koboldapi.model = $(this).val();
     saveSettingsDebounced();
 }
+*/
 
 /*
 function onKoboldOptChanged() {

--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,6 @@
     "js": "index.js",
     "css": "style.css",
     "author": "kawaiiwolf",
-    "version": "2.0.1",
+    "version": "2.1.0",
     "homePage": ""
 }


### PR DESCRIPTION
Adds 2 commands that output strings to better help with building QR based hot-swap menus.

`/kcpp-unload` uses whatever is in the `Unload models .kcpps config` field which is saved after testing by pressing the `Unload` button in the settings menu.